### PR TITLE
DSEC-1556: Workload Units for CloudSQL and BigQuery

### DIFF
--- a/gcp_resource_count.sh
+++ b/gcp_resource_count.sh
@@ -206,8 +206,8 @@ echo "Serverless Containers Count: $total_cloud_run (Workload Units: ${container
 echo "Container Images Count: $total_container_images (Workload Units: ${container_image_workloads})"
 echo "VM Images Count: $total_vm_images (Workload Units: ${vm_image_workloads})"
 echo "Container Hosts Count: $total_gke_nodes (Workload Units: ${container_host_workloads})"
-echo "CloudSQL Databases Count (up to $((MAX_DB_SIZE / 1000)) TB): $total_sql_dbs (Workload Units: ${cloudsql_workloads})"
-echo "BigQuery Datasets Count: $total_bigquery_datasets (Workload Units: ${dataset_workloads})"
+echo "Managed Databases Count (up to $((MAX_DB_SIZE / 1000)) TB): $total_sql_dbs (Workload Units: ${cloudsql_workloads})"
+echo "DataWarehouses Count: $total_bigquery_datasets (Workload Units: ${dataset_workloads})"
 echo "--------------------------------------"
 echo "TOTAL Estimated Workload Units: ${total_workloads}"
 echo

--- a/gcp_resource_count.sh
+++ b/gcp_resource_count.sh
@@ -25,7 +25,7 @@ _make_temp_file() {
 }
 
 PROJECT_ID=""
-MAX_DB_SIZE=1100
+MAX_DB_SIZE_GB=1100
 
 while [[ $# -gt 0 ]]
 do
@@ -36,8 +36,8 @@ do
         shift # past argument
         shift # past value
         ;;
-        -s|--max-db-size)
-        MAX_DB_SIZE="$2"
+        -s|--max-db-size-gb)
+        MAX_DB_SIZE_GB="$2"
         shift # past argument
         shift # past value
         ;;
@@ -60,7 +60,7 @@ else
     echo "[+] counting resources for project ${PROJECT_ID}"
 fi
 echo
-echo "Max DB Size: ${MAX_DB_SIZE}GB"
+echo "Max DB Size: ${MAX_DB_SIZE_GB}GB"
 
 total_vms=0
 total_functions=0
@@ -135,7 +135,7 @@ for project in $PROJECTS; do
 
     # Fetch Cloud SQL databases
     gcloud -q sql instances list --project "${project}" --format json > ${_temp_project_output} 2>> $LOG_FILE || echo "Failed to get Cloud SQL DBs for project ${project}"
-    project_managed_db_count=$(cat "${_temp_project_output}" | jq -r --argjson max_db_size "$MAX_DB_SIZE" '[.[] | select(.state == "RUNNABLE" and ((.settings.dataDiskSizeGb // "0") | tonumber) <= $max_db_size)] | length')
+    project_managed_db_count=$(cat "${_temp_project_output}" | jq -r --argjson max_db_size_gb "$MAX_DB_SIZE_GB" '[.[] | select(.state == "RUNNABLE" and ((.settings.dataDiskSizeGb // "0") | tonumber) <= $max_db_size_gb)] | length')
     if [ -n "$project_managed_db_count" ]; then
       total_managed_dbs=$((total_managed_dbs + project_managed_db_count))
       echo "Managed Databases Count: $project_managed_db_count"
@@ -206,7 +206,7 @@ echo "Serverless Containers Count: $total_cloud_run (Workload Units: ${container
 echo "Container Images Count: $total_container_images (Workload Units: ${container_image_workloads})"
 echo "VM Images Count: $total_vm_images (Workload Units: ${vm_image_workloads})"
 echo "Container Hosts Count: $total_gke_nodes (Workload Units: ${container_host_workloads})"
-echo "Managed Databases Count (up to $((MAX_DB_SIZE / 1024)) TB): $total_managed_dbs (Workload Units: ${managed_db_workloads})"
+echo "Managed Databases Count (up to $((MAX_DB_SIZE_GB / 1024)) TB): $total_managed_dbs (Workload Units: ${managed_db_workloads})"
 echo "DataWarehouses Count: $total_datawarehouses_datasets (Workload Units: ${datawarehouse_workloads})"
 echo "--------------------------------------"
 echo "TOTAL Estimated Workload Units: ${total_workloads}"

--- a/gcp_resource_count.sh
+++ b/gcp_resource_count.sh
@@ -25,7 +25,7 @@ _make_temp_file() {
 }
 
 PROJECT_ID=""
-MAX_DB_SIZE_GB=1100
+MAX_DB_SIZE_GB=1024
 
 while [[ $# -gt 0 ]]
 do


### PR DESCRIPTION
```
(base) [devenv1] ~/s/orca-poc ❯❯❯ ./gcp_resource_count.sh -p tortit                                                                                                                        DSEC-1556/list-gcp-dbs ◼
[+] counting resources for project tortit

Max DB Size: 1100GB
Processing Project: tortit
Virtual Machines Count: 3
Serverless Functions Count: 1
Failed to get Serverless Containers for project tortit
Container Images Count: 2
VM images Count: 1
Cloud SQL Databases Count: 3
BigQuery Datasets Count: 2


==============
Total results:
==============
Virtual Machines Count: 3 (Workload Units: 3)
Serverless Functions Count: 1 (Workload Units: 1)
Serverless Containers Count: 0 (Workload Units: 0)
Container Images Count: 2 (Workload Units: 1)
VM Images Count: 1 (Workload Units: 1)
Container Hosts Count: 0 (Workload Units: 0)
Managed Databases Count (up to 1 TB): 3 (Workload Units: 3)
DataWarehouses Count: 2 (Workload Units: 2)
--------------------------------------
TOTAL Estimated Workload Units: 11
```